### PR TITLE
Fixing wildcard imports and typos

### DIFF
--- a/Clause.java
+++ b/Clause.java
@@ -1,4 +1,4 @@
-import java.util.*;
+import java.util.ArrayList;
 
 /* Defines a clause as a list of disjuncts */
 public class Clause

--- a/DPLLSolver.java
+++ b/DPLLSolver.java
@@ -1,4 +1,4 @@
-import java.util.*;
+import java.util.ArrayList;
 
 public class DPLLSolver
 {

--- a/DimacsParser.java
+++ b/DimacsParser.java
@@ -1,5 +1,8 @@
-import java.io.*;
-import java.util.*;
+import java.io.BufferedReader;
+import java.io.FileNotFoundException;
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.ArrayList;
 
 /* A class responsible for parsing files in the DIMACS format.
    The primary parseDimacs() method returns a list of clauses */
@@ -38,7 +41,7 @@ public class DimacsParser
 		}
 		catch(FileNotFoundException e)
 		{
-			System.out.println("File not found! Exitting...");
+			System.out.println("File not found! Exiting...");
 			System.exit(0);
 		}
 
@@ -111,7 +114,7 @@ public class DimacsParser
 		}
 		catch(IOException e)
 		{
-			System.out.println("IOException! Exitting...");
+			System.out.println("IOException! Exiting...");
 			System.exit(0);
 		}
 
@@ -122,7 +125,7 @@ public class DimacsParser
 		}
 		catch(IOException e)
 		{
-			System.out.println("IOException! Exitting...");
+			System.out.println("IOException! Exiting...");
 			System.exit(0);
 		}
 

--- a/NanoSat.java
+++ b/NanoSat.java
@@ -3,8 +3,7 @@
  * @author Hassan Zaidi
  */
 
-import java.util.*;
-import java.lang.Math.*;
+import java.util.ArrayList;
 
 public class NanoSat
 {


### PR DESCRIPTION
According to [Google Java Style Guide](https://google.github.io/styleguide/javaguide.html#s3.3.1-wildcard-imports), wildcard imports should not be used because they make code difficult to reason about. 
